### PR TITLE
Don't force JSON::Type annotations on users

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ registration_ids= ["12", "13"] # an array of one or more client registration tok
 options = {
   "data": {
     "score": "123"
-  } of String => JSON::Type,
+  },
   "collapse_key": "updated_score"
-} of String => JSON::Type
+}
 response = gcm.send(registration_ids, options)
 
 Response is an object containing body, headers, status and canonical_ids/not_registered_ids. Check [here](https://developers.google.com/cloud-messaging/http#response) to see how to interpret the responses.

--- a/spec/gcm_spec.cr
+++ b/spec/gcm_spec.cr
@@ -77,7 +77,7 @@ Spec2.describe GCM do
       response.canonical_ids = [] of GCM::CanonicalID
       response.not_registered_ids = [] of String
       response.response = "success"
-      expect(gcm.send(registration_ids, {} of String => JSON::Type)).to eq(response)
+      expect(gcm.send(registration_ids)).to eq(response)
       expect(stub_gcm_send_request.calls).to eq(1)
     end
 
@@ -94,12 +94,7 @@ Spec2.describe GCM do
       response.not_registered_ids = [] of String
       response.response = "success"
 
-      options = {
-        "data": {
-          "a": "b"
-        } of String => JSON::Type
-      } of String => JSON::Type
-      expect(gcm.send(registration_ids, {} of String => JSON::Type)).to eq(response)
+      expect(gcm.send(registration_ids)).to eq(response)
       expect(stub_gcm_send_request_with_basic_auth.calls).to eq(1)
     end
 
@@ -118,9 +113,9 @@ Spec2.describe GCM do
         options = {
           "data": {
             "score": "5x1",
-            "time": "15:10"
-          } of String => JSON::Type
-        } of String => JSON::Type
+            "time":  "15:10",
+          },
+        }
 
         gcm.send(registration_ids, options)
 


### PR DESCRIPTION
This PR does these things:
1. It doesn't force users to put `JSON::Type` annotations.
2. It unifies the `send` method into a single one with a default value of `nil`. This makes it consume less memory because an empty hash is avoided when no options are specified.
3. It uses `String.build` and `io.json_object` to build the JSON string to send to the server, instead of merging the "registration_ids" in the hash (which forces it to be of JSON::Type). This, as a side effect, makes the code faster.

I guess https://github.com/crystal-lang/crystal/issues/2532 was because of this. Crystal idioms are different than Ruby, and in most cases idiomatic Crystal code doesn't need type annotations and is more efficient than the equivalent Ruby code. When reporting an issue, I would suggest not only discussing the compiler error, but what you intend to do with the code, so we can, together (me and the community) find the best solution for the problem instead of using workarounds ;-)

Check [JSON](http://crystal-lang.org/api/JSON.html) and [JSON::Builder](http://crystal-lang.org/api/JSON/Builder.html) documentation.
